### PR TITLE
Bugfix/LRA-742-art-survey-errors-displaying-images-on-staging-server

### DIFF
--- a/app/controllers/art_items_controller.rb
+++ b/app/controllers/art_items_controller.rb
@@ -6,17 +6,7 @@ class ArtItemsController < ApplicationController
 
   # GET /art_items or /art_items.json
   def index
-    # if params[:q].nil?
-      @q = get_artitems_collection.ransack(params[:q])
-    # else
-    #   if
-    #     params[:q][:archived_true].present? && params[:q][:archived_true] == "0"
-    #     @q = get_artitems_collection.ransack(params[:q])
-    #   else
-    #     @q = get_artitems_collection.ransack(params[:q])
-    #   end
-    # end
-
+    @q = get_artitems_collection.ransack(params[:q])
     @art_items = @q.result.order('department.fullname')
     @departments_result = @art_items.pluck(:department_id).uniq
     @appraisal_type_ids = get_artitems_collection.pluck(:appraisal_type_id).uniq.sort

--- a/app/views/art_items/_form.html.erb
+++ b/app/views/art_items/_form.html.erb
@@ -66,7 +66,7 @@
   </div>
 
   <div id="attached_files" class="my-5">
-    <%= form.label :documents, "Documents (pdf,txt,jpg,png,doc)" %><span class="optional-text"> * optional</span>
+    <%= form.label :documents, "Documents (pdf,txt,doc)" %><span class="optional-text"> * optional</span>
     <%= form.file_field :documents, multiple: true, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
 
@@ -79,19 +79,21 @@
         <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
           <ul class="border border-gray-200 rounded-md divide-y divide-gray-200">
             <% @art_item.documents.each do |doc| %>
-              <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
-                <div class="w-0 flex-1 flex items-center">
-                  <i class="fas fa-paperclip text-gray-400"></i>
-                  <span class="ml-2 flex-1 w-0 truncate">
-                    <%= link_to doc.filename, url_for(doc), target: "_blank" %>
-                  </span>
-                  <% unless doc.id.nil? %>
-                      <button type="button" class="bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                        <%= link_to 'Remove', delete_file_path(doc), data: {turbo_method: :get, turbo_confirm: 'Are you sure?'} %>
-                      </button>
-                  <% end %>
-                </div>
-              </li>
+              <% unless doc.id.nil? %>
+                <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
+                  <div class="w-0 flex-1 flex items-center">
+                    <i class="fas fa-paperclip text-gray-400"></i>
+                    <span class="ml-2 flex-1 w-0 truncate">
+                      <%= link_to doc.filename, url_for(doc), target: "_blank" %>
+                    </span>
+                    <% unless doc.id.nil? %>
+                        <button type="button" class="bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                          <%= link_to 'Remove', delete_file_path(doc), data: {turbo_method: :get, turbo_confirm: 'Are you sure?'} %>
+                        </button>
+                    <% end %>
+                  </div>
+                </li>
+              <% end %>
             <% end %>
           </ul>
         </dd>
@@ -112,14 +114,16 @@
     <% art_item.images.each do |image| %>
       <li class="relative">
         <div class="flex flex-col">
-          <div class="group block w-full h-40 rounded-lg bg-gray-100 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-gray-100 focus-within:ring-indigo-500 overflow-hidden">
-            <%= image_tag image.variant(:thumb), class: "object-cover h-full w-full group-hover:opacity-75" %>
-          </div>
-          <div>
-            <button type="button" class="bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-              <%= link_to 'Remove', delete_file_path(image), data: {turbo_method: :get, turbo_confirm: 'Are you sure?'} %>
-            </button>
-          </div>
+          <% if image.variable? %>
+            <div class="group block w-full h-40 rounded-lg bg-gray-100 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-gray-100 focus-within:ring-indigo-500 overflow-hidden">
+              <%= image_tag image.variant(:thumb), class: "object-cover h-full w-full group-hover:opacity-75" %>
+            </div>
+            <div>
+              <button type="button" class="bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                <%= link_to 'Remove', delete_file_path(image), data: {turbo_method: :get, turbo_confirm: 'Are you sure?'} %>
+              </button>
+            </div>
+          <% end %>
         </div>
       </li>
       


### PR DESCRIPTION
There was an issue with non image types being allowed into the system. This PR establishes a validation check for all images that are uploaded.
I also rewrote the document validation and moved bith validations into a private section of the class.
There are checks in the form view to allwo the errors to display and to prevent bad files artifacts from presenting during the file update workflow.