### PR TITLE
Add ReportsController for generating art items report

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,65 @@
+require "csv"
+
+class ReportsController < ApplicationController
+  before_action :super_user_department_admin_access_authorized!
+
+  def art_items
+    @departments = current_user_department_objects
+    @selected_department = params[:department_id].present? ? Department.find_by(id: params[:department_id]) : nil
+
+    art_items = if is_super_user!
+      if @selected_department
+        ArtItem.where(department: @selected_department)
+      else
+        ArtItem.all
+      end
+    else
+      ArtItem.where(department_id: current_user_departments)
+    end
+
+    art_items = art_items.includes(:department, :appraisal_type, images_attachments: :blob)
+
+    respond_to do |format|
+      format.html # renders app/views/reports/art_items.html.erb
+      format.csv do
+        send_data art_items_to_csv(art_items), filename: "art_items_report-#{Time.zone.today}.csv"
+      end
+    end
+  end
+
+  private
+
+  def art_items_to_csv(art_items)
+    headers = [
+      'Department',
+      'Department Contact',
+      'Description',
+      'Location Building',
+      'Location Room',
+      'Value Cost',
+      'Date Acquired',
+      'Appraisal Type',
+      'Protection',
+      'Appraisal Description',
+      'Image URL'
+    ]
+    CSV.generate(headers: true) do |csv|
+      csv << headers
+      art_items.find_each do |item|
+        csv << [
+          item.department&.fullname,
+          item.department_contact,
+          item.description&.body&.to_plain_text,
+          item.location_building,
+          item.location_room,
+          item.value_cost,
+          item.date_acquired,
+          item.appraisal_type&.classification,
+          item.protection&.body&.to_plain_text,
+          item.appraisal_description&.body&.to_plain_text,
+          item.images.attached? ? url_for(item.images.first) : ''
+        ]
+      end
+    end
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -14,7 +14,7 @@ class ReportsController < ApplicationController
         ArtItem.all
       end
     else
-      ArtItem.where(department_id: current_user_departments)
+      ArtItem.where(department: current_user_departments)
     end
 
     art_items = art_items.includes(:department, :appraisal_type, images_attachments: :blob)

--- a/app/views/layouts/_nav_links.html.erb
+++ b/app/views/layouts/_nav_links.html.erb
@@ -5,6 +5,8 @@
     <% if is_super_user! || is_department_admin_user! %>
       <%= link_to "Users", accesses_path,
           class: "#{mobile ? 'block w-full px-4 py-2 text-base font-medium text-white hover:bg-blue-700 rounded-md transition-colors' : 'border-transparent text-blue-50 hover:border-blue-300 hover:text-white inline-flex items-center pr-1 pt-1 border-b-2 text-base font-normal'} #{class_names(active: current_page?(accesses_path))}" %>
+      <%= link_to "Reports", art_items_reports_path,
+          class: "#{mobile ? 'block w-full px-4 py-2 text-base font-medium text-white hover:bg-blue-700 rounded-md transition-colors' : 'border-transparent text-blue-50 hover:border-blue-300 hover:text-white inline-flex items-center pr-1 pt-1 border-b-2 text-base font-normal'} #{class_names(active: current_page?(art_items_reports_path))}" %>
     <% end %>
     <%= link_to "https://docs.google.com/document/d/e/2PACX-1vTKMfzTxp2I02KuuT_3S5t2OOA4vUIZObWUgnslilQSuh1XBUQgmTpODJGmyoLWZ5UkN-adzSBQgBc7/pub#h.zf7fqp6cccac",
         target: "_blank",

--- a/app/views/reports/art_items.html.erb
+++ b/app/views/reports/art_items.html.erb
@@ -1,0 +1,27 @@
+<%# app/views/reports/art_items.html.erb %>
+<h1 class="text-2xl font-bold mb-4">Art Items Report</h1>
+
+<% if @departments.any? %>
+  <%= form_with url: art_items_reports_path, method: :get, local: true, html: { id: 'report-form', class: 'mb-6' } do |form| %>
+    <div class="mb-4">
+      <%= form.label :department_id, 'Department', class: 'block font-semibold mb-1' %>
+      <%= form.select :department_id, options_for_select([['All Departments', '']] + @departments.map { |d| [d.fullname, d.id] }, @selected_department&.id), {}, class: 'border rounded px-3 py-2 w-full', id: 'department_id_select' %>
+    </div>
+  <% end %>
+  <%= button_to 'Download CSV', art_items_reports_path(format: :csv), method: :get, params: {}, class: 'bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded', id: 'download-csv-btn' %>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      var btn = document.getElementById('download-csv-btn');
+      var select = document.getElementById('department_id_select');
+      btn.addEventListener('click', function(e) {
+        e.preventDefault();
+        var depId = select.value;
+        var url = '<%= art_items_reports_path(format: :csv) %>';
+        if(depId) { url += '?department_id=' + encodeURIComponent(depId); }
+        window.location = url;
+      });
+    });
+  </script>
+<% else %>
+  <div class="text-red-600">No departments available for your account.</div>
+<% end %>

--- a/app/views/reports/art_items.html.erb
+++ b/app/views/reports/art_items.html.erb
@@ -8,7 +8,7 @@
       <%= form.select :department_id, options_for_select([['All Departments', '']] + @departments.map { |d| [d.fullname, d.id] }, @selected_department&.id), {}, class: 'border rounded px-3 py-2 w-full', id: 'department_id_select' %>
     </div>
   <% end %>
-  <%= button_to 'Download CSV', art_items_reports_path(format: :csv), method: :get, params: {}, class: 'bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded', id: 'download-csv-btn' %>
+  <%= link_to 'Download CSV', art_items_reports_path(format: :csv), class: 'bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded', id: 'download-csv-btn' %>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
       var btn = document.getElementById('download-csv-btn');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,12 +6,17 @@ Rails.application.routes.draw do
   get 'art_item_images/index'
   resources :art_items do
     resources :art_item_images, only: :index
-  end  
+  end
   resources :accesses
   resources :permissions
   resources :departments
   resources :appraisal_types
   resources :roles
+  resources :reports, only: [] do
+    collection do
+      get :art_items
+    end
+  end
 
   get 'art_items/delete_file_attachment/:id', to: 'art_items#delete_file_attachment', as: :delete_file
 

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -68,4 +68,24 @@ RSpec.describe ReportsController, type: :controller do
       expect(response).to redirect_to(root_path)
     end
   end
+
+  describe 'department selection in @departments' do
+    let!(:other_department) { create(:department, fullname: 'Photography') }
+
+    it 'SuperUser sees all departments' do
+      allow(controller).to receive(:is_super_user!).and_return(true)
+      allow(controller).to receive(:is_department_admin_user!).and_return(false)
+      allow(controller).to receive(:current_user_department_objects).and_return([department1, department2, other_department])
+      get :art_items
+      expect(assigns(:departments)).to match_array([department1, department2, other_department])
+    end
+
+    it 'Department Admin sees only their assigned departments' do
+      allow(controller).to receive(:is_super_user!).and_return(false)
+      allow(controller).to receive(:is_department_admin_user!).and_return(true)
+      allow(controller).to receive(:current_user_department_objects).and_return([department2])
+      get :art_items
+      expect(assigns(:departments)).to eq([department2])
+    end
+  end
 end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+require 'csv'
+
+RSpec.describe ReportsController, type: :controller do
+  let!(:super_user_role) { create(:role, title: 'SuperUser') }
+  let!(:dept_admin_role) { create(:role, title: 'Department Administrator') }
+  let!(:department1) { create(:department, fullname: 'Painting') }
+  let!(:department2) { create(:department, fullname: 'Sculpture') }
+  let!(:appraisal_type) { create(:appraisal_type, classification: 'Standard') }
+  let!(:art_item1) do
+    create(:art_item, department: department1, department_contact: 'Alice', description: 'Desc1', location_building: 'A', location_room: '101', value_cost: 1000, date_acquired: '2020-01-01', appraisal_type: appraisal_type, protection: 'Prot1', appraisal_description: 'AppDesc1')
+  end
+  let!(:art_item2) do
+    create(:art_item, department: department2, department_contact: 'Bob', description: 'Desc2', location_building: 'B', location_room: '202', value_cost: 2000, date_acquired: '2021-01-01', appraisal_type: appraisal_type, protection: 'Prot2', appraisal_description: 'AppDesc2')
+  end
+
+  before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
+    allow(controller).to receive(:current_user_department_objects).and_return([department1, department2])
+    allow(controller).to receive(:current_user_departments).and_return([department1.id, department2.id])
+  end
+
+  describe 'GET #art_items as SuperUser' do
+    before do
+      allow(controller).to receive(:is_super_user!).and_return(true)
+      allow(controller).to receive(:is_department_admin_user!).and_return(false)
+    end
+
+    it 'returns all art_items as CSV' do
+      get :art_items, format: :csv
+      csv = CSV.parse(response.body, headers: true)
+      expect(csv.count).to eq(2)
+      expect(csv.headers).to include('Department', 'Department Contact', 'Description', 'Location Building', 'Location Room', 'Value Cost', 'Date Acquired', 'Appraisal Type', 'Protection', 'Appraisal Description', 'Image URL')
+    end
+
+    it 'filters by department' do
+      get :art_items, params: { department_id: department1.id }, format: :csv
+      csv = CSV.parse(response.body, headers: true)
+      expect(csv.count).to eq(1)
+      expect(csv[0]['Department']).to eq('Painting')
+    end
+  end
+
+  describe 'GET #art_items as Department Admin' do
+    before do
+      allow(controller).to receive(:is_super_user!).and_return(false)
+      allow(controller).to receive(:is_department_admin_user!).and_return(true)
+      allow(controller).to receive(:current_user_departments).and_return([department1.id])
+      allow(controller).to receive(:current_user_department_objects).and_return([department1])
+    end
+
+    it 'returns only their department art_items as CSV' do
+      get :art_items, format: :csv
+      csv = CSV.parse(response.body, headers: true)
+      expect(csv.count).to eq(1)
+      expect(csv[0]['Department']).to eq('Painting')
+    end
+  end
+
+  describe 'GET #art_items as unauthorized user' do
+    before do
+      allow(controller).to receive(:is_super_user!).and_return(false)
+      allow(controller).to receive(:is_department_admin_user!).and_return(false)
+    end
+
+    it 'redirects to root' do
+      get :art_items
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end


### PR DESCRIPTION
- Implemented `ReportsController` with `art_items` action to fetch and display art items based on user permissions.
- Added CSV export functionality for art items.
- Created view for art items report with department selection and CSV download button.
- Updated navigation links to include the new reports section.
- Added RSpec tests for the ReportsController to ensure proper functionality and access control.