### PR TITLE
Add uniqname search to Access index page.

### DIFF
--- a/app/controllers/accesses_controller.rb
+++ b/app/controllers/accesses_controller.rb
@@ -5,7 +5,17 @@ class AccessesController < ApplicationController
 
   # GET /accesses or /accesses.json
   def index
-    @accesses = get_accesses_collection.sort_by { |ac| ac.permission.department_full_name }
+    base_collection = get_accesses_collection.includes(permission: [:department, :role])
+    @q = base_collection.ransack(params[:q])
+    @accesses = @q.result.sort_by { |ac| ac.permission.department_full_name }
+    @uniqnames_for_filter = base_collection.distinct.pluck(:uniqname).sort
+
+    unless params[:q].nil?
+      render turbo_stream: turbo_stream.replace(
+        :accessesListing,
+        partial: "accesses/listing"
+      )
+    end
   end
 
   # GET /accesses/1 or /accesses/1.json

--- a/app/models/access.rb
+++ b/app/models/access.rb
@@ -15,4 +15,8 @@ class Access < ApplicationRecord
   validates :uniqname, presence: true
   validates :updated_by, presence: true
   validates :permission_id, presence: true, uniqueness: { scope: :uniqname }
+
+  def self.ransackable_attributes(_auth = nil)
+    %w[uniqname permission_id updated_by]
+  end
 end

--- a/app/views/accesses/_listing.html.erb
+++ b/app/views/accesses/_listing.html.erb
@@ -1,0 +1,28 @@
+<div id="accessesListing">
+  <div class="-mx-4 mt-8 overflow-x-auto shadow ring-1 ring-black ring-opacity-5 sm:-mx-6 md:mx-0 md:rounded-lg">
+    <table class="min-w-full divide-y divide-gray-300">
+      <thead class="bg-gray-50">
+        <tr>
+          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Permission</th>
+          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell">Uniqname</th>
+          <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 lg:table-cell">Updated by</th>
+          <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
+            <span class="sr-only">Edit</span>
+          </th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-200 bg-white">
+      <% @accesses.each do |access| %>
+        <tr class="even:bg-blue-50">
+          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-900 lg:table-cell lg:pl-6"><%= show_department_fullname(access.permission.department_id) %> - <%= show_role_title(access.permission.role_id) %></td>
+          <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900"><%= show_user_name_by_uniqname(access.uniqname) %></td>
+          <td class="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 lg:table-cell"><%= show_user_name_by_id(access.updated_by) %></td>
+          <td class="whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
+            <%= link_to "Show", access_path(access), class: "text-indigo-600 hover:text-indigo-900" %>
+          </td>
+        </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/accesses/index.html.erb
+++ b/app/views/accesses/index.html.erb
@@ -8,30 +8,30 @@
       <%= link_to 'Add User', new_access_path, class: "inline-flex items-center justify-center rounded-md border border-transparent bg-blue-umblue px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-white hover:text-blue-umblue hover:ring-2 hover:ring-blue-umblue focus:outline-none focus:ring-2 focus:ring-blue-umblue focus:ring-offset-2 sm:w-auto" %>
     </div>
   </div>
-  <div class="-mx-4 mt-8 overflow-x-auto shadow ring-1 ring-black ring-opacity-5 sm:-mx-6 md:mx-0 md:rounded-lg">
-    <table class="min-w-full divide-y divide-gray-300">
-      <thead class="bg-gray-50">
-        <tr>
-          <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">Permission</th>
-          <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell">Uniqname</th>
-          <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 lg:table-cell">Updated by</th>
-          <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
-            <span class="sr-only">Edit</span>
-          </th>
-        </tr>
-      </thead>
-      <tbody class="divide-y divide-gray-200 bg-white">
-      <% @accesses.each do |access| %>
-        <tr class="even:bg-blue-50">
-          <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-900 lg:table-cell lg:pl-6"><%= show_department_fullname(access.permission.department_id) %> - <%= show_role_title(access.permission.role_id) %></td>
-          <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900"><%= show_user_name_by_uniqname(access.uniqname) %></td>
-          <td class="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 lg:table-cell"><%= show_user_name_by_id(access.updated_by) %></td>
-          <td class="whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-            <%= link_to "Show", access_path(access), class: "text-indigo-600 hover:text-indigo-900" %>
-          </td>
-        </tr>
-        <% end %>
-      </tbody>
-    </table>
+
+  <div class="mt-6" data-controller="autosubmit">
+    <%= search_form_for @q, data: { target: "autosubmit.form", action: "input->autosubmit#search" } do |form| %>
+      <div>
+        <label for="q_uniqname_eq"><span class="fancy_label">Search Uniqname</span></label>
+        <%= form.text_field :uniqname_eq,
+          placeholder: "Enter or select uniqname",
+          list: "uniqname-options",
+          class: "input_text_field mt-2",
+          "data-action": "input->autosubmit#search",
+          "aria-labelledby": "q_uniqname_eq" %>
+        <datalist id="uniqname-options">
+          <% @uniqnames_for_filter.each do |uniqname| %>
+            <option value="<%= uniqname %>"></option>
+          <% end %>
+        </datalist>
+      </div>
+      <div class="mt-3">
+        <button type="button" class="tertiary_button" data-action="click->autosubmit#clearFilters">
+          Clear
+        </button>
+      </div>
+    <% end %>
   </div>
+
+  <%= render 'listing' %>
 </div>

--- a/spec/controllers/accesses_controller_spec.rb
+++ b/spec/controllers/accesses_controller_spec.rb
@@ -51,6 +51,21 @@ RSpec.describe AccessesController, type: :controller do
         get :index
         expect(response).to be_successful
       end
+
+      it "assigns all accesses when no search params are present" do
+        get :index
+        expect(assigns(:accesses).map(&:id)).to match_array(Access.pluck(:id))
+      end
+
+      it "filters accesses by uniqname when search params are present" do
+        get :index, params: { q: { uniqname_eq: super_user.uniqname } }
+        expect(assigns(:accesses).map(&:uniqname)).to eq([super_user.uniqname])
+      end
+
+      it "renders turbo stream when search params are present" do
+        get :index, params: { q: { uniqname_eq: super_user.uniqname } }, format: :turbo_stream
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      end
     end
 
     describe "GET #show" do
@@ -146,7 +161,8 @@ RSpec.describe AccessesController, type: :controller do
   end
 
   describe "for authenticated department admin user" do
-    let(:dept_access) { create(:access, uniqname: "dept_user", permission: dept_admin_permission, updated_by: 1) }
+    let!(:dept_access) { create(:access, uniqname: "dept_user", permission: dept_admin_permission, updated_by: 1) }
+    let!(:other_dept_access) { create(:access, uniqname: "other_dept_user", permission: create(:permission, role: dept_admin_role, department: other_department), updated_by: 1) }
 
     before do
       # Skip Devise authentication
@@ -161,13 +177,28 @@ RSpec.describe AccessesController, type: :controller do
       allow(controller).to receive(:super_user_access_authorized!).and_return(false)
       allow(controller).to receive(:super_user_department_admin_access_authorized!).and_return(true)
       allow(controller).to receive(:current_user_associated_department_permissions).and_return([dept_admin_permission])
-      allow(controller).to receive(:get_accesses_collection).and_return([dept_access])
+      allow(controller).to receive(:get_accesses_collection).and_return(Access.where(id: dept_access.id))
     end
 
     describe "GET #index" do
       it "returns a success response" do
         get :index
         expect(response).to be_successful
+      end
+
+      it "assigns only scoped accesses when no search params are present" do
+        get :index
+        expect(assigns(:accesses).map(&:id)).to eq([dept_access.id])
+      end
+
+      it "filters scoped accesses by uniqname when search params are present" do
+        get :index, params: { q: { uniqname_eq: "dept_user" } }
+        expect(assigns(:accesses).map(&:uniqname)).to eq(["dept_user"])
+      end
+
+      it "does not return accesses outside department scoping when filtering" do
+        get :index, params: { q: { uniqname_eq: "other_dept_user" } }
+        expect(assigns(:accesses)).to be_empty
       end
     end
 


### PR DESCRIPTION
This pull request adds search and filtering functionality to the Accesses index page, allowing users to filter accesses by uniqname with a responsive UI. It also refactors the view to use a partial for the accesses listing and introduces Turbo Streams for seamless updates. Comprehensive tests are added to cover the new search behavior and ensure proper scoping.

**Feature: Search and filtering for accesses**
- Adds Ransack-based search to the `index` action in `AccessesController`, enabling filtering by `uniqname` and updating the view via Turbo Streams for a dynamic user experience. (`app/controllers/accesses_controller.rb`, [app/controllers/accesses_controller.rbL8-R18](diffhunk://#diff-c384b7552086702af06827f078f33265ce06024c21069c1a8fc6655ccad9657cL8-R18))
- Exposes only the relevant attributes (`uniqname`, `permission_id`, `updated_by`) for searching in the `Access` model. (`app/models/access.rb`, [app/models/access.rbR18-R21](diffhunk://#diff-35ee3576b36545b0e663dfc0f061de6e06b0c3b6b2e9a77fc161a4a02eccaee2R18-R21))

**UI Refactor and Turbo Streams**
- Refactors the accesses table into a new partial (`_listing.html.erb`) and renders it via Turbo Stream when search parameters are present. (`app/views/accesses/_listing.html.erb`, [[1]](diffhunk://#diff-7286035f32e8c205d51cf8a39a5d6d373fd1528add40e3b934a33abad587b060R1-R28); `app/views/accesses/index.html.erb`, [[2]](diffhunk://#diff-2bd2fdf7fe2f3ed0e4740a3209f623c89c0c3982f32fd839dc940a1309be3597L11-R36)
- Adds a search form with autosubmit and a uniqname datalist for improved usability. (`app/views/accesses/index.html.erb`, [app/views/accesses/index.html.erbL11-R36](diffhunk://#diff-2bd2fdf7fe2f3ed0e4740a3209f623c89c0c3982f32fd839dc940a1309be3597L11-R36))

**Testing**
- Adds controller specs to verify search/filter behavior, Turbo Stream rendering, and correct scoping for both super users and department admins. (`spec/controllers/accesses_controller_spec.rb`, [[1]](diffhunk://#diff-5ce36426e5f0c1061695826a595726295122f960f9feb1988efa686569a8f46cR54-R68) [[2]](diffhunk://#diff-5ce36426e5f0c1061695826a595726295122f960f9feb1988efa686569a8f46cL149-R165) [[3]](diffhunk://#diff-5ce36426e5f0c1061695826a595726295122f960f9feb1988efa686569a8f46cL164-R202)Let SuperUsers and Dept Admins filter assigned accesses by uniqname using Ransack, autosubmit, and Turbo Stream updates.